### PR TITLE
Handle shorthand in load options detection

### DIFF
--- a/src/services/Collector.ts
+++ b/src/services/Collector.ts
@@ -36,9 +36,13 @@ export class Collector {
       node.getText() === "loadOptions"
     ) {
       const objectLiteralExpression = node.parent.getChildAt(2);
-      objectLiteralExpression.forEachChild((methodDeclaration) => {
-        const identifier = methodDeclaration.getChildAt(1);
-        Collector.loadOptionsMethods.push(identifier.getText());
+      objectLiteralExpression.forEachChild((method) => {
+        if (ts.isShorthandPropertyAssignment(method)) {
+          Collector.loadOptionsMethods.push(method.getText());
+        } else {
+          const identifier = method.getChildAt(1);
+          Collector.loadOptionsMethods.push(identifier.getText());
+        }
       });
     }
   }


### PR DESCRIPTION
To close #13.

```ts
methods = {
		loadOptions: {
				getTableNames,

				async getTableUpdateAbleColumns(this: ILoadOptionsFunctions) {
						const tableName = this.getNodeParameter('tableName', undefined);
						if (undefined === tableName) return [];
						const columns = await apiDtableColumns.call(this, undefined, tableName as string);
						return toOptions(updateAble(columns));
				},
		},
};
```